### PR TITLE
Moving the dependency to be non-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,7 @@
         }
     ],
     "require": {
-        "php": ">=5.6.4"
-    },
-    "require-dev": {
+        "php": ">=5.6.4",
         "friendsofphp/php-cs-fixer": "^2.0"
     },
     "autoload": {


### PR DESCRIPTION
When including the package into another repository, sometimes the `friendsofphp/php-cs-fixer` dependency wouldn't get installed. Moving this dependency out of the `require-dev` and into the `require` section resolves this issue.

This should be fine as it _should_ only be added to a projects `require-dev` section anyway.